### PR TITLE
Fix build problems on OSX

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,9 +18,14 @@ platforms = supported_platforms()
 script = raw"""
 cd $WORKSPACE/srcdir
 cp -r cspice/src/cspice/ .
-cmake -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain
-make
-make install
+
+# Create generated cmake files outside of source tree
+mkdir build
+cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ..
+make -j${nproc} VERBOSE=1
+make install VERBOSE=1
 """
 
 products = prefix -> [

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -9,7 +9,7 @@ if(WIN32)
 endif()
 include(GNUInstallDirs)
 
-set(CMAKE_C_FLAGS "-O2 -DNON_UNIX_STDIO")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -DNON_UNIX_STDIO")
 
 add_library(cspice SHARED ${SRCS})
 if(WIN32)


### PR DESCRIPTION
The CMake toolchain already defines a value for `${CMAKE_C_FLAGS}`, so
just calling `set()` on it overwrites these flags.  This is critical on
any platform that uses `clang` (such as `OSX`) because those platforms
require passing the `-target` argument to `clang`, as otherwise `clang`
is configured to output `x86_64-linux-gnu` object code.  This patch
causes the build script to append to this variable, instead of replacing
it.

This also follows the more typical pattern of putting all
CMake-generated output within a `build` subdirectory.  This is not
essential, but was my first step in separating out what was and was not
important when building.